### PR TITLE
Uniquify buffer name while renaming to avoid throwing errors.

### DIFF
--- a/modules/ohai-dired.el
+++ b/modules/ohai-dired.el
@@ -57,14 +57,12 @@
     (if (not (and filename (file-exists-p filename)))
         (error "Buffer '%s' is not visiting a file!" name)
       (let ((new-name (read-file-name "New name: " filename)))
-        (if (get-buffer new-name)
-            (error "A buffer named '%s' already exists!" new-name)
-          (rename-file filename new-name 1)
-          (rename-buffer new-name)
-          (set-visited-file-name new-name)
-          (set-buffer-modified-p nil)
-          (message "File '%s' successfully renamed to '%s'"
-                   name (file-name-nondirectory new-name)))))))
+        (rename-file filename new-name 1)
+        (rename-buffer new-name t)
+        (set-visited-file-name new-name)
+        (set-buffer-modified-p nil)
+        (message "File '%s' successfully renamed to '%s'"
+                 name (file-name-nondirectory new-name))))))
 (global-set-key (kbd "C-x C-r") 'rename-current-buffer-file)
 
 


### PR DESCRIPTION
Currently if there is a conflict while renaming buffers, it is manually handled by throwing an error. This commit changes that to uniquify the buffer name automatically. This is done by passing the additional argument to the call to `rename-buffer`, which calls `generate-new-buffer-name` underneath to create the unique name.
