### PR TITLE
Removes a reference to a mode that breaks magit

### DIFF
--- a/modules/ohai-appearance.el
+++ b/modules/ohai-appearance.el
@@ -163,7 +163,6 @@
 (eval-after-load "cider" '(diminish 'cider-mode))
 (eval-after-load "smartparens" '(diminish 'smartparens-mode))
 (eval-after-load "git-gutter" '(diminish 'git-gutter-mode))
-(eval-after-load "magit" '(diminish 'magit-auto-revert-mode))
 
 (eval-after-load "js2-mode"
   '(defadvice js2-mode (after js2-rename-modeline activate)


### PR DESCRIPTION
- The latest magit does not seem to have the magit-auto-revert-mode
