### PR TITLE
Use HTTPS for MELPA, security++

### DIFF
--- a/ohai/ohai-package.el
+++ b/ohai/ohai-package.el
@@ -37,7 +37,7 @@
 ;; to use MELPA as well.
 (setq package-user-dir (concat dotfiles-dir "elpa"))
 (require 'package)
-(add-to-list 'package-archives '("melpa" . "http://melpa.org/packages/") t)
+(add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/") t)
 
 ;; To get the package manager going, we invoke its initialise function.
 (package-initialize)


### PR DESCRIPTION
Use HTTPS for getting packages to help prevent man-in-the-middle attacks.
