### PR TITLE
Engage Nyan Cat only when possible!

### DIFF
--- a/modules/ohai-appearance.el
+++ b/modules/ohai-appearance.el
@@ -112,7 +112,13 @@
   (setq frame-title-format '(buffer-file-name "%f" ("%b")))
   (tooltip-mode -1)
   (mouse-wheel-mode t)
-  (blink-cursor-mode -1))
+  (blink-cursor-mode -1)
+
+  ;; Engage Nyan Cat!
+  (package-require 'nyan-mode)
+  (nyan-mode 1)
+  (setq nyan-bar-length 16
+	nyan-wavy-trail t))
 
 ;; Show line numbers in buffers.
 (global-linum-mode t)
@@ -140,11 +146,6 @@
 ;; Highlight matching braces.
 (show-paren-mode 1)
 
-;; Engage Nyan Cat!
-(package-require 'nyan-mode)
-(nyan-mode 1)
-(setq nyan-bar-length 16
-      nyan-wavy-trail t)
 
 ;; Unclutter the modeline
 (package-require 'diminish)


### PR DESCRIPTION
Terminal Emacs 24.5.1 on OS X (as provided by Homebrew with default flags) chokes on nyan-mode when starting up with the error:

```
error: invalid image type 'xpm'
```

This may not be the best possible fix (I'm new to elisp/emacs config), but it works for me.
