### PR TITLE
Refactor elixir checker to accept phoenix projects

### DIFF
--- a/modules/ohai-elixir.el
+++ b/modules/ohai-elixir.el
@@ -45,10 +45,11 @@
 (with-eval-after-load "flycheck"
   (flycheck-define-checker elixir-mix
     "An Elixir syntax checker using the Elixir interpreter.
-See URL `http://elixir-lang.org/'."
+     See URL `http://elixir-lang.org/'."
     :command ("mix"
               "compile"
               source)
+    :predicate is-mix-project-p
     :error-patterns
     ((error line-start "** (" (zero-or-more not-newline) ") "
             (zero-or-more not-newline) ":" line ": " (message) line-end)

--- a/modules/ohai-elixir.el
+++ b/modules/ohai-elixir.el
@@ -61,7 +61,9 @@
     :modes elixir-mode)
   (add-to-list 'flycheck-checkers 'elixir-mix))
 
-
+(defun is-mix-project-p ()
+  (let ((mix-project-root (locate-dominating-file (buffer-file-name) "mix.exs")))
+    (if mix-project-root (cd mix-project-root) nil)))
 
 (provide 'ohai-elixir)
 ;;; ohai-elixir.el ends here

--- a/modules/ohai-elixir.el
+++ b/modules/ohai-elixir.el
@@ -52,9 +52,9 @@
     :predicate is-mix-project-p
     :error-patterns
     ((error line-start "** (" (zero-or-more not-newline) ") "
-            (zero-or-more not-newline) ":" line ": " (message) line-end)
+            (file-name) ":" line ": " (message) line-end)
      (warning line-start
-              (one-or-more (not (syntax whitespace))) ":"
+              (file-name) ":"
               line ": "
               (message)
               line-end))


### PR DESCRIPTION
The elixir checker uses the `mix compile` command. This command
has to be executed from the root of the project containing
the `mix.exs` config file.

The commit allows the checker to find this root directory and launch
the command from here, giving access to all libs dependencies.

This is kind of a hack. An issue exist in the flycheck project:
https://github.com/flycheck/flycheck/issues/312

Any feedback and improvement are more than welcome.
