### PR TITLE
Switch to use-package for package management

### DIFF
--- a/modules/ohai-appearance.el
+++ b/modules/ohai-appearance.el
@@ -62,7 +62,7 @@
 ;; Configure the dark colour scheme.
 (defun ohai-appearance/dark ()
   (interactive)
-  (package-require 'material-theme)
+  (use-package material-theme)
   (load-theme 'material)
 
   (set-face-background 'default "#000")
@@ -121,8 +121,9 @@
 (setq linum-format (if (not window-system) "%4d " "%4d"))
 
 ;; Highlight the line number of the current line.
-(package-require 'hlinum)
-(hlinum-activate)
+(use-package hlinum
+  :config
+  (hlinum-activate))
 
 ;; Show column numbers in modeline.
 (setq column-number-mode t)
@@ -143,35 +144,27 @@
 (show-paren-mode 1)
 
 ;; Engage Nyan Cat!
-(package-require 'nyan-mode)
-(nyan-mode 1)
-(setq nyan-bar-length 16
-      nyan-wavy-trail t)
+(use-package nyan-mode
+  :config
+  (nyan-mode 1)
+  (setq nyan-bar-length 16
+        nyan-wavy-trail t))
 
 ;; Unclutter the modeline
-(package-require 'diminish)
-(eval-after-load "yasnippet" '(diminish 'yas-minor-mode))
-(eval-after-load "ethan-wspace" '(diminish 'ethan-wspace-mode))
+(use-package diminish)
+
+
 (eval-after-load "eldoc" '(diminish 'eldoc-mode))
-(eval-after-load "rainbow-mode" '(diminish 'rainbow-mode))
-(eval-after-load "paredit" '(diminish 'paredit-mode))
 (eval-after-load "autopair" '(diminish 'autopair-mode))
 (eval-after-load "abbrev" '(diminish 'abbrev-mode))
-(eval-after-load "company" '(diminish 'company-mode))
 (eval-after-load "js2-highlight-vars" '(diminish 'js2-highlight-vars-mode))
-(eval-after-load "projectile" '(diminish 'projectile-mode))
 (eval-after-load "mmm-mode" '(diminish 'mmm-mode))
 (eval-after-load "skewer-html" '(diminish 'skewer-html-mode))
 (eval-after-load "skewer-mode" '(diminish 'skewer-mode))
 (eval-after-load "auto-indent-mode" '(diminish 'auto-indent-minor-mode))
-(eval-after-load "highlight-parentheses" '(diminish 'highlight-parentheses-mode))
 ;; (eval-after-load "subword" '(diminish 'subword-mode))
-(eval-after-load "anzu" '(diminish 'anzu-mode))
 (eval-after-load "cider" '(diminish 'cider-mode))
 (eval-after-load "smartparens" '(diminish 'smartparens-mode))
-(eval-after-load "git-gutter" '(diminish 'git-gutter-mode))
-(eval-after-load "volatile-highlights" '(diminish 'volatile-highlights-mode))
-(eval-after-load "which-key" '(diminish 'which-key-mode))
 
 (eval-after-load "js2-mode"
   '(defadvice js2-mode (after js2-rename-modeline activate)

--- a/modules/ohai-clojure.el
+++ b/modules/ohai-clojure.el
@@ -20,44 +20,37 @@
 
 ;;; Code:
 
-(package-require 'clojure-mode)
-
-;; We'll be using Monroe, a simple nREPL client. To use it, you'll need
-;; to start an nREPL somewhere (running `lein repl' in your project should
-;; do the trick) and run `M-x monroe' to connect to it and open a REPL
-;; buffer.
-(package-require 'monroe)
-
-;; We'll also be using clj-refactor for refactoring support. The features
-;; which require CIDER won't work with Monroe.
-(package-require 'clj-refactor)
-
-;; We might need Paredit too if that's how you like it.
-(package-require 'paredit)
-
-;; Setup
-(add-hook
- 'clojure-mode-hook
- (lambda ()
-   (when ohai-personal-taste/paredit (paredit-mode))
-   (clj-refactor-mode 1)
-   (require 'monroe)
-   (clojure-enable-monroe)))
-
-(with-eval-after-load "clojure-mode"
-  ;; Rebind C-x C-e to eval through nREPL in clojure-mode buffers.
-  (define-key clojure-mode-map (kbd "C-x C-e")
-    'monroe-eval-expression-at-point)
-  ;; Define the keybinding prefix for clj-refactor commands.
-  ;; From there, see https://github.com/clojure-emacs/clj-refactor.el#usage
-  (cljr-add-keybindings-with-prefix "C-c C-m"))
-
-;; Monroe doesn't offer any completion support. Let's build on it to
-;; add a company-mode backend which queries the connected nREPL for
-;; completions.
-(with-eval-after-load "clojure-mode"
+(use-package clojure-mode
+  :config
+  ;; Setup
+  (add-hook
+   'clojure-mode-hook
+   (lambda ()
+     (when ohai-personal-taste/paredit (paredit-mode))
+     (clj-refactor-mode 1)
+     ;; We'll be using Monroe, a simple nREPL client. To use it, you'll need
+     ;; to start an nREPL somewhere (running `lein repl' in your project should
+     ;; do the trick) and run `M-x monroe' to connect to it and open a REPL
+     ;; buffer.
+     (use-package monroe
+       :config
+       (clojure-enable-monroe)
+       :bind (
+              ;; Rebind C-x C-e to eval through nREPL in clojure-mode buffers.
+              :map clojure-mode-map
+                   ("C-x C-e" . monroe-eval-expression-at-point)))
+     ;; We'll also be using clj-refactor for refactoring support. The features
+     ;; which require CIDER won't work with Monroe.
+     (use-package clj-refactor
+       :config
+       ;; Define the keybinding prefix for clj-refactor commands.
+       ;; From there, see https://github.com/clojure-emacs/clj-refactor.el#usage
+       (cljr-add-keybindings-with-prefix "C-c C-m"))))
+  ;; Monroe doesn't offer any completion support. Let's build on it to
+  ;; add a company-mode backend which queries the connected nREPL for
+  ;; completions.
+  ;; <shafi>: there should be a better way to do this
   (with-eval-after-load "company"
-
     (defun monroe-eval-string (s callback)
       (monroe-send-eval-string
        s
@@ -92,6 +85,10 @@
                  (monroe-get-completions arg callback))))))
 
     (add-to-list 'company-backends 'company-monroe)))
+
+;; We might need Paredit too if that's how you like it.
+(use-package paredit
+  :diminish paredit-mode)
 
 (provide 'ohai-clojure)
 ;;; ohai-clojure.el ends here

--- a/modules/ohai-codestyle.el
+++ b/modules/ohai-codestyle.el
@@ -36,11 +36,14 @@
 ;; and automatically clean up your code when saving.
 ;; Use C-c c to instantly clean up your file.
 ;; Read more about ethan-wspace: https://github.com/glasserc/ethan-wspace
-(package-require 'ethan-wspace)
+(use-package ethan-wspace
+  :config
+  (global-ethan-wspace-mode 1)
+  :bind ("C-c c" . ethan-wspace-clean-all)
+  :diminish ethan-wspace-mode)
+
 (setq mode-require-final-newline nil)
 (setq require-final-newline nil)
-(global-ethan-wspace-mode 1)
-(global-set-key (kbd "C-c c") 'ethan-wspace-clean-all)
 
 ;; Set default indentation for various languages (add your own!)
 (setq-default tab-width 4)

--- a/modules/ohai-complete.el
+++ b/modules/ohai-complete.el
@@ -23,59 +23,54 @@
 (require 'ohai-package)
 (require 'ohai-appearance)
 
-(package-require 'company)
-
-;; Enable company-mode globally.
-(require 'company)
-(global-company-mode)
-
-;; Except when you're in term-mode.
-(setq company-global-modes '(not term-mode))
-
-;; Give Company a decent default configuration.
-(setq company-minimum-prefix-length 2
-      company-selection-wrap-around t
-      company-show-numbers t
-      company-tooltip-align-annotations t
-      company-require-match nil
-      company-dabbrev-downcase nil
-      company-dabbrev-ignore-case nil)
-
-;; Sort completion candidates that already occur in the current
-;; buffer at the top of the candidate list.
-(setq company-transformers '(company-sort-by-occurrence))
-
-;; Show documentation where available for selected completion
-;; after a short delay.
-(package-require 'company-quickhelp)
-(setq company-quickhelp-delay 1)
-(company-quickhelp-mode 1)
-
-;; Add a completion source for emoji. 😸
-(package-require 'company-emoji)
-(company-emoji-init)
-
-;; Company's default colours look OK with the light scheme,
-;; but hideous with the dark one, so let's pick something nicer.
-(add-hook
- 'ohai-appearance/dark-hook
- (lambda ()
-   (set-face-foreground 'company-tooltip "#000")
-   (set-face-background 'company-tooltip "#ddd")
-   (set-face-background 'company-scrollbar-bg "#fff")
-   (set-face-background 'company-scrollbar-fg "#999")
-   (set-face-background 'company-tooltip-selection "#aaa")
-   (set-face-foreground 'company-tooltip-common "#9a0000")
-   (set-face-foreground 'company-tooltip-common-selection "#9a0000")
-   (set-face-foreground 'company-tooltip-annotation "#00008e")))
-
-;; Use C-\ to activate the Company autocompleter.
-;; We invoke company-try-hard to gather completion candidates from multiple
-;; sources if the active source isn't being very forthcoming.
-(package-require 'company-try-hard)
-(global-set-key (kbd "C-\\") #'company-try-hard)
-(define-key company-active-map (kbd "C-\\") #'company-try-hard)
-
-
+(use-package company
+  :config
+  ;; Enable company-mode globally.
+  (global-company-mode)
+  ;; Except when you're in term-mode.
+  (setq company-global-modes '(not term-mode))
+  ;; Give Company a decent default configuration.
+  (setq company-minimum-prefix-length 2
+        company-selection-wrap-around t
+        company-show-numbers t
+        company-tooltip-align-annotations t
+        company-require-match nil
+        company-dabbrev-downcase nil
+        company-dabbrev-ignore-case nil)
+  ;; Sort completion candidates that already occur in the current
+  ;; buffer at the top of the candidate list.
+  (setq company-transformers '(company-sort-by-occurrence))
+  ;; Show documentation where available for selected completion
+  ;; after a short delay.
+  (use-package company-quickhelp
+    :config
+    (setq company-quickhelp-delay 1)
+    (company-quickhelp-mode 1))
+  ;; Add a completion source for emoji. 😸
+  (use-package company-emoji
+    :config
+    (company-emoji-init))
+  ;; Company's default colours look OK with the light scheme,
+  ;; but hideous with the dark one, so let's pick something nicer.
+  (add-hook
+   'ohai-appearance/dark-hook
+   (lambda ()
+     (set-face-foreground 'company-tooltip "#000")
+     (set-face-background 'company-tooltip "#ddd")
+     (set-face-background 'company-scrollbar-bg "#fff")
+     (set-face-background 'company-scrollbar-fg "#999")
+     (set-face-background 'company-tooltip-selection "#aaa")
+     (set-face-foreground 'company-tooltip-common "#9a0000")
+     (set-face-foreground 'company-tooltip-common-selection "#9a0000")
+     (set-face-foreground 'company-tooltip-annotation "#00008e")))
+  ;; Use C-\ to activate the Company autocompleter.
+  ;; We invoke company-try-hard to gather completion candidates from multiple
+  ;; sources if the active source isn't being very forthcoming.
+  (use-package company-try-hard
+    :bind ("C-\\" . company-try-hard)
+    :config
+    (bind-keys :map company-active-map
+               ("C-\\" . company-try-hard)))
+  :diminish company-mode)
 
 (provide 'ohai-complete)

--- a/modules/ohai-dired.el
+++ b/modules/ohai-dired.el
@@ -22,10 +22,11 @@
 
 ;; dired+ is an enhanced version of the built-in Emacs directory editor.
 ;; Learn about how it extends Dired: http://www.emacswiki.org/emacs/DiredPlus
-(setq diredp-hide-details-initially-flag nil)
-(package-require 'dired+)
-(require 'dired+)
-(set-face-foreground 'diredp-file-name nil)
+(use-package dired+
+  :init
+  (setq diredp-hide-details-initially-flag nil)
+  :config
+  (set-face-foreground 'diredp-file-name nil))
 
 ;; Keep dired buffers updated when the file system changes.
 (setq global-auto-revert-non-file-buffers t)

--- a/modules/ohai-editing.el
+++ b/modules/ohai-editing.el
@@ -28,23 +28,24 @@
 ;; Select a region and C-M-' to place cursors on each line of the selection.
 ;; Bonus: <insert> key no longer activates overwrite mode.
 ;; What is that thing for anyway?
-(package-require 'multiple-cursors)
-(global-set-key (kbd "<insert>") 'mc/mark-next-like-this)
-(global-set-key (kbd "S-<insert>") 'mc/mark-previous-like-this)
-(global-set-key (kbd "C-'") 'mc/mark-more-like-this-extended)
-(global-set-key (kbd "C-\"") 'mc/mark-all-like-this-dwim)
-(global-set-key (kbd "C-M-'") 'mc/edit-lines)
-
-;; MC has `mc-hide-unmatched-lines-mode' bound to C-', which interferes
-;; with our ability to add more cursors, so we'll just clear the binding.
-;; TODO: add `mc-hide-unmatched-lines-mode' back somewhere else?
-(define-key mc/keymap (kbd "C-'") nil)
+(use-package multiple-cursors
+  :config
+  ;; MC has `mc-hide-unmatched-lines-mode' bound to C-', which interferes
+  ;; with our ability to add more cursors, so we'll just clear the binding.
+  ;; TODO: add `mc-hide-unmatched-lines-mode' back somewhere else?
+  (bind-keys :map mc/keymap
+             ("C-'" . nil))
+  :bind (("<insert>" . mc/mark-next-like-this)
+	 ("S-<insert>" . mc/mark-previous-like-this)
+	 ("C-'" . mc/mark-more-like-this-extended)
+	 ("C-\"" . mc/mark-all-like-this-dwim)
+	 ("C-M-'" . mc/edit-lines)))
 
 ;; Use C-= to select the innermost logical unit your cursor is on.
 ;; Keep hitting C-= to expand it to the next logical unit.
 ;; Protip: this goes really well with multiple cursors.
-(package-require 'expand-region)
-(global-set-key (kbd "C-=") 'er/expand-region)
+(use-package expand-region
+  :bind ("C-=" . er/expand-region))
 
 ;; Remap join-line to M-j where it's easier to get to.
 ;; join-line will join the line you're on with the line above it
@@ -134,14 +135,13 @@
 
 ;; A key for intelligently shrinking whitespace.
 ;; See https://github.com/jcpetkovich/shrink-whitespace.el for details.
-(package-require 'shrink-whitespace)
-(global-set-key (kbd "C-c DEL") 'shrink-whitespace)
+(use-package shrink-whitespace
+  :bind ("C-c DEL" . shrink-whitespace))
 
 ;; Highlight changed areas with certain operations, such as undo, kill, yank.
-(package-require 'volatile-highlights)
-(require 'volatile-highlights)
-(volatile-highlights-mode t)
-
-
+(use-package volatile-highlights
+  :config
+  (volatile-highlights-mode t)
+  :diminish volatile-highlights-mode)
 
 (provide 'ohai-editing)

--- a/modules/ohai-elisp.el
+++ b/modules/ohai-elisp.el
@@ -26,15 +26,18 @@
 ;; If you're ready for Paredit, let's do Paredit!
 ;; Learn Paredit: http://pub.gajendra.net/src/paredit-refcard.pdf
 (when ohai-personal-taste/paredit
-  (package-require 'paredit)
-  (add-hook 'emacs-lisp-mode-hook 'enable-paredit-mode))
-
-;; Setup C-c v to eval whole buffer in all lisps.
-(define-key lisp-mode-shared-map (kbd "C-c v") 'eval-buffer)
+  (use-package paredit
+    :config
+    (add-hook 'emacs-lisp-mode-hook 'enable-paredit-mode)
+    ;; Setup C-c v to eval whole buffer in all lisps.
+    (define-key lisp-mode-shared-map (kbd "C-c v") 'eval-buffer)
+    :diminish paredit-mode))
 
 ;; Highlight the sexp under the cursor.
-(package-require 'highlight-parentheses)
-(add-hook 'emacs-lisp-mode-hook 'highlight-parentheses-mode)
+(use-package highlight-parentheses
+  :config
+  (add-hook 'emacs-lisp-mode-hook 'highlight-parentheses-mode)
+  :diminish highlight-parentheses-mode)
 
 ;; When saving an elisp file, remove its compiled version if
 ;; there is one, as you'll want to recompile it.

--- a/modules/ohai-elixir.el
+++ b/modules/ohai-elixir.el
@@ -23,22 +23,21 @@
 (require 'ohai-package)
 
 ;; Set up the basic Elixir mode.
-(package-require 'elixir-mode)
-
-;; Alchemist offers integration with the Mix tool.
-(package-require 'alchemist)
-(with-eval-after-load "elixir-mode"
+(use-package elixir-mode
+  :config
   (add-hook 'elixir-mode-hook 'alchemist-mode))
 
-;; Bind some Alchemist commands to more commonly used keys.
-(with-eval-after-load "alchemist"
-  (define-key alchemist-mode-map
-    (kbd "C-c C-l")
-    (lambda () (interactive)
-      (save-buffer)
-      (alchemist-iex-compile-this-buffer)))
-  (define-key alchemist-mode-map
-    (kbd "C-x C-e") 'alchemist-iex-send-current-line))
+;; Alchemist offers integration with the Mix tool.
+(use-package alchemist
+    ;;:commands (alchemist-mode)
+    :config
+    ;; Bind some Alchemist commands to more commonly used keys.
+    (bind-keys :map alchemist-mode-map
+               ("C-c C-l" . (lambda () (interactive)
+                               (save-buffer)
+                               (alchemist-iex-compile-this-buffer))))
+    (bind-keys :map alchemist-mode-map
+               ("C-x C-e" . alchemist-iex-send-current-line)))
 
 ;; A Flycheck checker that uses Mix, so it finds project deps.
 ;; From https://github.com/ananthakumaran/dotfiles/blob/master/.emacs.d/init-elixir.el#L25-L42

--- a/modules/ohai-emoji.el
+++ b/modules/ohai-emoji.el
@@ -20,18 +20,17 @@
 
 ;;; Code:
 
-(package-require 'emojify)
-(require 'emojify)
-
-;; Set emojify to only replace Unicode emoji, and do it everywhere.
-(setq emojify-emoji-styles '(unicode)
-      emojify-inhibit-major-modes '())
+(use-package emojify
+  :config
+  ;; Set emojify to only replace Unicode emoji, and do it everywhere.
+  (setq emojify-emoji-styles '(unicode)
+        emojify-inhibit-major-modes '())
+  ;; Enable it globally.
+  (add-hook 'after-init-hook #'global-emojify-mode))
 
 ;; Patch emojify to replace emoji everywhere in programming modes.
 (defun emojify-valid-prog-context-p (beg end) 't)
 
-;; Enable it globally.
-(add-hook 'after-init-hook #'global-emojify-mode)
 
 
 

--- a/modules/ohai-erlang.el
+++ b/modules/ohai-erlang.el
@@ -23,7 +23,16 @@
 (require 'ohai-package)
 
 ;; Let's use the regular erlang-mode
-(package-require 'erlang)
+(use-package erlang
+  :config
+  ;; Setup C-c e to add an export clause for the function under cursor.
+  (add-hook 'erlang-mode-hook (lambda () (local-set-key "\C-ce" 'erlang-export)))
+
+  ;; Avoid Warning about final newline with Erlang mode
+  (add-hook 'erlang-mode-hook
+            (lambda ()
+              (setq require-final-newline nil)
+              (setq mode-require-final-newline nil))))
 
 (defun stripwhite (str)
   "Remove any whitespace from STR."
@@ -70,13 +79,6 @@
 (defun erlang-forward-arg ()
   (forward-sexp))
 
-;; Setup C-c e to add an export clause for the function under cursor.
-(add-hook 'erlang-mode-hook (lambda () (local-set-key "\C-ce" 'erlang-export)))
 
-;; Avoid Warning about final newline with Erlang mode
-(add-hook 'erlang-mode-hook
-          (lambda ()
-            (setq require-final-newline nil)
-            (setq mode-require-final-newline nil)))
 
 (provide 'ohai-erlang)

--- a/modules/ohai-eshell.el
+++ b/modules/ohai-eshell.el
@@ -33,12 +33,14 @@
       '(("git" "log" "l" "diff" "show")))
 
 ;; Suggest alternatives for mistyped commands.
-;; (package-require 'eshell-did-you-mean)
-;; (eshell-did-you-mean-setup)
+;; (use-package eshell-did-you-mean
+;;   :config
+;;   (eshell-did-you-mean-setup))
 
 ;; Define a pretty prompt.
-(package-require 'eshell-git-prompt)
-(eshell-git-prompt-use-theme 'powerline)
+(use-package eshell-git-prompt
+  :config
+  (eshell-git-prompt-use-theme 'powerline))
 
 (setq eshell-cmpl-cycle-completions nil)
 

--- a/modules/ohai-flow.el
+++ b/modules/ohai-flow.el
@@ -26,7 +26,7 @@
   (add-to-list 'projectile-project-root-files ".flowconfig"))
 
 ;; There's no Flow major mode, so we'll fake it by copying TypeScript's.
-(package-require 'typescript-mode)
+(use-package typescript-mode)
 (define-derived-mode flow-mode typescript-mode "Flow"
   "JavaScript with Flow type checking")
 

--- a/modules/ohai-flycheck.el
+++ b/modules/ohai-flycheck.el
@@ -23,26 +23,27 @@
 (require 'ohai-package)
 
 ;; Install Flycheck.
-(package-require 'flycheck)
-
-;; Start it automatically for all modes except ELisp mode,
-;; where the linter is just designed to make you mad.
-(add-hook 'find-file-hook
-          (lambda ()
-            (when (not (equal 'emacs-lisp-mode major-mode))
-              (flycheck-mode))))
+(use-package flycheck
+  :config
+  ;; Start it automatically for all modes except ELisp mode,
+  ;; where the linter is just designed to make you mad.
+  (add-hook 'find-file-hook
+            (lambda ()
+              (when (not (equal 'emacs-lisp-mode major-mode))
+                (flycheck-mode)))))
 
 ;; Jump between current errors with M-n and M-p.
 (global-set-key (kbd "M-n") 'next-error)
 (global-set-key (kbd "M-p") 'previous-error)
 
 ;; Turn the modeline red when Flycheck has errors.
-(package-require 'flycheck-color-mode-line)
+(use-package flycheck-color-mode-line
+  :config
+  ;; Configure the theme.
+  (with-eval-after-load "flycheck"
+    (setq flycheck-highlighting-mode 'symbols)
+    (add-hook 'flycheck-mode-hook 'flycheck-color-mode-line-mode)))
 
-;; Configure the theme.
-(with-eval-after-load "flycheck"
-  (setq flycheck-highlighting-mode 'symbols)
-  (add-hook 'flycheck-mode-hook 'flycheck-color-mode-line-mode))
 
 (add-hook
  'ohai-appearance/dark-hook

--- a/modules/ohai-git.el
+++ b/modules/ohai-git.el
@@ -24,17 +24,18 @@
 
 ;; Invoke Magit by typing C-x g, and you can thank me later.
 ;; See http://magit.github.io/ for instructions.
-(package-require 'magit)
-(global-set-key (kbd "C-x g") 'magit-status)
+(use-package magit
+  :bind ("C-x g" . magit-status))
 
 ;; Use M-x gist-buffer or M-x gist-region to create a gist
 ;; directly from the current buffer or selection.
-(package-require 'gist)
+(use-package gist)
 
 ;; Mark uncommitted changes in the fringe.
-(package-require 'git-gutter-fringe)
-(require 'git-gutter-fringe)
-(global-git-gutter-mode t)
+(use-package git-gutter-fringe
+  :config
+  (global-git-gutter-mode t)
+  :diminish git-gutter-mode)
 
 
 

--- a/modules/ohai-haskell.el
+++ b/modules/ohai-haskell.el
@@ -20,46 +20,50 @@
 
 ;;; Code:
 
-(package-require 'haskell-mode)
-
-;; Setup haskell-mode hooks
-(with-eval-after-load "haskell-mode"
+(use-package haskell-mode
+  :config
+  ;; Setup haskell-mode hooks
   (custom-set-variables
    '(haskell-mode-hook
      '(turn-on-haskell-indentation
-       turn-on-haskell-doc))))
-
-;; Setup haskell-interactive-mode keybindings. Get started by using C-c C-z from
-;; a buffer visiting a file in your Haskell project.
-(with-eval-after-load "haskell-mode"
+       turn-on-haskell-doc)))
+  ;; Setup haskell-interactive-mode keybindings. Get started by using C-c C-z from
+  ;; a buffer visiting a file in your Haskell project.
   ;; Switch to the current REPL buffer, starting a session if needed.
-  (define-key haskell-mode-map (kbd "C-c C-z") 'haskell-interactive-switch)
+  (bind-keys :map haskell-mode-map
+             ("C-c C-z" . haskell-interactive-switch))
   ;; Switch between REPL sessions.
-  (define-key haskell-mode-map (kbd "C-c b") 'haskell-session-change)
+  (bind-keys :map haskell-mode-map
+             ("C-c b" . haskell-session-change))
   ;; Load the current buffer into the REPL.
-  (define-key haskell-mode-map (kbd "C-c C-l") 'haskell-process-load-file)
+  (bind-keys :map haskell-mode-map
+             ("C-c C-l" . haskell-process-load-file))
   ;; Infer the type of the thing at point.
-  (define-key haskell-mode-map (kbd "C-c C-t") 'haskell-process-do-type)
+  (bind-keys :map haskell-mode-map
+             ("C-c C-t" . haskell-process-do-type))
   ;; Display info (in the REPL) about the thing at point.
-  (define-key haskell-mode-map (kbd "C-c C-i") 'haskell-process-do-info)
+  (bind-keys :map haskell-mode-map
+             ("C-c C-i" . haskell-process-do-info))
   ;; Insert the inferred type of the function at point into the code.
-  (define-key haskell-mode-map (kbd "C-c C-s") (lambda () (interactive) (haskell-process-do-type t)))
+  (bind-keys :map haskell-mode-map
+             ("C-c C-s" . (lambda () (interactive) (haskell-process-do-type t))))
   ;; Run `cabal test' in a compile buffer.
-  (define-key haskell-mode-map (kbd "C-c C-,") 'ohai-haskell/run-test-suite))
+  (bind-keys :map haskell-mode-map
+             ("C-c C-," . ohai-haskell/run-test-suite))
+  ;; Change some ASCII art syntax into their corresponding Unicode characters.
+  ;; Rebind the same Unicode characters to insert their ASCII art versions
+  ;; if entered from the keyboard.
+  ;; This is very much a matter of taste, feel free to disable it. Or better yet,
+  ;; if you're into that sort of thing, see https://wiki.haskell.org/Unicode-symbols
+  ;; for native Unicode support.
+  (with-eval-after-load "haskell-mode"
+    (ohai/font-lock-replace-symbol 'haskell-mode "\\(->\\)" "→")
+    (ohai/font-lock-replace-symbol 'haskell-mode "\\(<-\\)" "←")
+    (ohai/font-lock-replace-symbol 'haskell-mode "\\(=>\\)" "⇒")
+    (define-key haskell-mode-map (kbd "→") (lambda () (interactive) (insert "->")))
+    (define-key haskell-mode-map (kbd "←") (lambda () (interactive) (insert "<-")))
+    (define-key haskell-mode-map (kbd "⇒") (lambda () (interactive) (insert "=>")))))
 
-;; Change some ASCII art syntax into their corresponding Unicode characters.
-;; Rebind the same Unicode characters to insert their ASCII art versions
-;; if entered from the keyboard.
-;; This is very much a matter of taste, feel free to disable it. Or better yet,
-;; if you're into that sort of thing, see https://wiki.haskell.org/Unicode-symbols
-;; for native Unicode support.
-(with-eval-after-load "haskell-mode"
-  (ohai/font-lock-replace-symbol 'haskell-mode "\\(->\\)" "→")
-  (ohai/font-lock-replace-symbol 'haskell-mode "\\(<-\\)" "←")
-  (ohai/font-lock-replace-symbol 'haskell-mode "\\(=>\\)" "⇒")
-  (define-key haskell-mode-map (kbd "→") (lambda () (interactive) (insert "->")))
-  (define-key haskell-mode-map (kbd "←") (lambda () (interactive) (insert "<-")))
-  (define-key haskell-mode-map (kbd "⇒") (lambda () (interactive) (insert "=>"))))
 
 ;; A function for launching a compile buffer with `cabal test'.
 (defun ohai-haskell/run-test-suite ()
@@ -69,10 +73,11 @@
     (compile "cabal test")))
 
 ;; Flycheck addons
-(package-require 'flycheck-haskell)
-(with-eval-after-load "flycheck"
-  (with-eval-after-load "haskell"
-    (add-hook 'flycheck-mode-hook #'flycheck-haskell-setup)))
+(use-package flycheck-haskell
+  :config
+  (with-eval-after-load "flycheck"
+    (with-eval-after-load "haskell"
+      (add-hook 'flycheck-mode-hook #'flycheck-haskell-setup))))
 
 
 

--- a/modules/ohai-helm.el
+++ b/modules/ohai-helm.el
@@ -20,50 +20,45 @@
 
 ;;; Code:
 
-(package-require 'helm)
-(require 'helm-config)
-(require 'helm)
+(use-package helm
+  :config
+  (require 'helm-config)
+  (require 'helm)
+  ;; Activate Helm.
+  (helm-mode 1)
+  (with-eval-after-load "ohai-project"
+    (use-package helm-projectile
+      ;; A binding for using Helm to pick files using Projectile,
+      ;; and override the normal grep with a Projectile based grep.
+      :bind (("C-c C-f" . helm-projectile-find-file-dwim)
+             ("C-x C-g" . helm-projectile-grep))))
+  ;; Tell Helm to resize the selector as needed.
+  (helm-autoresize-mode 1)
+  ;; Make Helm look nice.
+  (setq-default helm-display-header-line nil
+                helm-autoresize-min-height 10
+                helm-autoresize-max-height 35
+                helm-split-window-in-side-p t
 
-;; Activate Helm.
-(helm-mode 1)
-
-;; Replace common selectors with Helm versions.
-(global-set-key (kbd "M-x") 'helm-M-x)
-(global-set-key (kbd "C-x C-f") 'helm-find-files)
-(global-set-key (kbd "C-x C-g") 'helm-do-grep)
-(global-set-key (kbd "C-x b") 'helm-buffers-list)
-(global-set-key (kbd "C-x c g") 'helm-google-suggest)
-(global-set-key (kbd "C-t") 'helm-imenu)
-(global-set-key (kbd "M-y") 'helm-show-kill-ring)
-
-;; A binding for using Helm to pick files using Projectile,
-;; and override the normal grep with a Projectile based grep.
-(with-eval-after-load "ohai-project"
-  (package-require 'helm-projectile)
-  (global-set-key (kbd "C-c C-f") 'helm-projectile-find-file-dwim)
-  (global-set-key (kbd "C-x C-g") 'helm-projectile-grep))
+                helm-M-x-fuzzy-match t
+                helm-buffers-fuzzy-matching t
+                helm-recentf-fuzzy-match t
+                helm-apropos-fuzzy-match t)
+  (set-face-attribute 'helm-source-header nil :height 0.75)
+  ;; Replace common selectors with Helm versions.
+  :bind (("M-x" . helm-M-x)
+         ("C-x C-f" . helm-find-files)
+         ("C-x C-g" . helm-do-grep)
+         ("C-x b" . helm-buffers-list)
+         ("C-x c g" . helm-google-suggest)
+         ("C-t" . helm-imenu)
+         ("M-y" . helm-show-kill-ring)))
 
 ;; Enrich isearch with Helm using the `C-S-s' binding.
 ;; swiper-helm behaves subtly different from isearch, so let's not
 ;; override the default binding.
-(package-require 'swiper-helm)
-(global-set-key (kbd "C-S-s") 'swiper-helm)
-
-;; Tell Helm to resize the selector as needed.
-(helm-autoresize-mode 1)
-
-;; Make Helm look nice.
-(setq-default helm-display-header-line nil
-              helm-autoresize-min-height 10
-              helm-autoresize-max-height 35
-              helm-split-window-in-side-p t
-
-              helm-M-x-fuzzy-match t
-              helm-buffers-fuzzy-matching t
-              helm-recentf-fuzzy-match t
-              helm-apropos-fuzzy-match t)
-
-(set-face-attribute 'helm-source-header nil :height 0.75)
+(use-package swiper-helm
+  :bind (("C-S-s" . swiper-helm)))
 
 ;; Bind C-c C-e to open a Helm selection of the files in your .emacs.d.
 ;; We get the whole list of files and filter it through `git check-ignore'
@@ -87,9 +82,9 @@
 (defun ohai-helm/files-in-repo (path success error)
   (let ((files (f-files path nil t)))
     (ohai-helm/gitignore path files
-                    (lambda (ignored)
-                      (funcall success (-difference files ignored)))
-                    error)))
+                         (lambda (ignored)
+                           (funcall success (-difference files ignored)))
+                         error)))
 
 (defun ohai-helm/find-files-in-emacs-d ()
   (interactive)

--- a/modules/ohai-help.el
+++ b/modules/ohai-help.el
@@ -24,25 +24,23 @@
 
 ;; which-key prompts you with available options when you type a partial
 ;; command sequence. Try it out: hit C-x and just wait for two seconds.
-(package-require 'which-key)
-(which-key-mode)
-
-;; Hit C-h C-k to have which-key show you all top level key bindings.
-(global-set-key (kbd "C-h C-k") 'which-key-show-top-level)
-
-;; Set the delay before which-key appears.
-(setq-default which-key-idle-delay 2.0)
-
-;; which-key will truncate special keys by default, eg. SPC turns into
-;; an orange D. Turn this off to avoid confusion.
-(setq-default which-key-special-keys nil)
-
-
+(use-package which-key
+  :demand t
+  :config
+  (which-key-mode)
+  ;; Set the delay before which-key appears.
+  (setq-default which-key-idle-delay 2.0)
+  ;; which-key will truncate special keys by default, eg. SPC turns into
+  ;; an orange D. Turn this off to avoid confusion.
+  (setq-default which-key-special-keys nil)
+  ;; Hit C-h C-k to have which-key show you all top level key bindings.
+  :bind ("C-h C-k" . which-key-show-top-level)
+  :diminish which-key-mode)
 
 ;; Get an instant cheat sheet for your current major mode
 ;; with C-h C-m.
-(package-require 'discover-my-major)
-(global-set-key (kbd "C-h C-m") 'discover-my-major)
+(use-package discover-my-major
+  :bind ("C-h C-m" . discover-my-major))
 
 
 

--- a/modules/ohai-html.el
+++ b/modules/ohai-html.el
@@ -26,33 +26,31 @@
 ;; web-mode is a special mode for HTML which copes with embedded JS/CSS,
 ;; JSX, various templating systems, etc.
 ;; Learn about web-mode: http://web-mode.org/
-(package-require 'web-mode)
-
-;; We'd like to use web-mode for HTML, instead of the default html-mode.
-(add-to-list 'auto-mode-alist '("\\.html?\\'" . web-mode))
-
-;; Let's add some extensions from the web-mode docs too.
-(add-to-list 'auto-mode-alist '("\\.phtml\\'" . web-mode))
-(add-to-list 'auto-mode-alist '("\\.tpl\\.php\\'" . web-mode))
-(add-to-list 'auto-mode-alist '("\\.[agj]sp\\'" . web-mode))
-(add-to-list 'auto-mode-alist '("\\.as[cp]x\\'" . web-mode))
-(add-to-list 'auto-mode-alist '("\\.erb\\'" . web-mode))
-(add-to-list 'auto-mode-alist '("\\.mustache\\'" . web-mode))
-(add-to-list 'auto-mode-alist '("\\.djhtml\\'" . web-mode))
-
-;; Highlight the element under the cursor.
-(setq-default web-mode-enable-current-element-highlight t)
-
-;; Key for renaming tags
-(with-eval-after-load "web-mode"
-  (define-key web-mode-map (kbd "C-c C-r") 'mc/mark-sgml-tag-pair))
+(use-package web-mode
+  :config
+  ;; We'd like to use web-mode for HTML, instead of the default html-mode.
+  (add-to-list 'auto-mode-alist '("\\.html?\\'" . web-mode))
+  ;; Let's add some extensions from the web-mode docs too.
+  (add-to-list 'auto-mode-alist '("\\.phtml\\'" . web-mode))
+  (add-to-list 'auto-mode-alist '("\\.tpl\\.php\\'" . web-mode))
+  (add-to-list 'auto-mode-alist '("\\.[agj]sp\\'" . web-mode))
+  (add-to-list 'auto-mode-alist '("\\.as[cp]x\\'" . web-mode))
+  (add-to-list 'auto-mode-alist '("\\.erb\\'" . web-mode))
+  (add-to-list 'auto-mode-alist '("\\.mustache\\'" . web-mode))
+  (add-to-list 'auto-mode-alist '("\\.djhtml\\'" . web-mode))
+  ;; Highlight the element under the cursor.
+  (setq-default web-mode-enable-current-element-highlight t)
+  ;; Key for renaming tags
+  (bind-keys :map web-mode-map
+             ("C-c C-r" . 'mc/mark-sgml-tag-pair)))
 
 ;; Colourise colour names in certain modes.
-(package-require 'rainbow-mode)
-(dolist (mode '(css-mode less-css-mode html-mode web-mode))
-  (add-hook (intern (concat (symbol-name mode) "-hook"))
-            (lambda () (rainbow-mode))))
-
+(use-package rainbow-mode
+  :config
+  (dolist (mode '(css-mode less-css-mode html-mode web-mode))
+    (add-hook (intern (concat (symbol-name mode) "-hook"))
+              (lambda () (rainbow-mode))))
+  :diminish rainbow-mode)
 
 
 (provide 'ohai-html)

--- a/modules/ohai-ido.el
+++ b/modules/ohai-ido.el
@@ -31,27 +31,32 @@
       ido-use-virtual-buffers t)
 
 ;; Make sure ido is really everywhere.
-(package-require 'ido-ubiquitous)
-(ido-ubiquitous-mode)
+(use-package ido-ubiquitous
+  :config
+  (ido-ubiquitous-mode))
+
 
 ;; Use smex to provide ido-like interface for M-x
-(package-require 'smex)
-(smex-initialize)
-(global-set-key (kbd "M-x") 'smex)
-(global-set-key (kbd "M-X") 'smex-major-mode-commands)
-;; This is the old M-x.
-(global-set-key (kbd "C-c C-c M-x") 'execute-extended-command)
+(use-package smex
+  :config
+  (smex-initialize)
+  :bind (("M-x" . smex)
+         ("M-X" . smex-major-mode-commands)
+         ;; This is the old M-x.
+         ("C-c C-c M-x" . execute-extended-command)))
 
 ;; Vertical ido.
-(package-require 'ido-vertical-mode)
-(ido-vertical-mode)
+(use-package ido-vertical-mode
+  :config
+  (ido-vertical-mode))
 
 ;; Improved fuzzy matching.
-(package-require 'flx-ido)
-(flx-ido-mode 1)
-(setq ido-enable-flex-matching t
-      ido-use-faces nil
-      gc-cons-threshold 20000000)
+(use-package flx-ido
+  :config
+  (flx-ido-mode 1)
+  (setq ido-enable-flex-matching t
+        ido-use-faces nil
+        gc-cons-threshold 20000000))
 
 ;; Bind C-t to use ido to jump to a symbol in the current buffer.
 (require 'imenu)
@@ -103,15 +108,15 @@ Symbols matching the text at point are put first in the completion list."
 ;; Bind `~` to go to homedir when in ido-find-file.
 ;; From http://whattheemacsd.com/setup-ido.el-02.html
 (add-hook 'ido-setup-hook
- (lambda ()
-   ;; Go straight home
-   (define-key ido-file-completion-map
-     (kbd "~")
-     (lambda ()
-       (interactive)
-       (if (looking-back "/")
-           (insert "~/")
-         (call-interactively 'self-insert-command))))))
+          (lambda ()
+            ;; Go straight home
+            (define-key ido-file-completion-map
+              (kbd "~")
+              (lambda ()
+                (interactive)
+                (if (looking-back "/")
+                    (insert "~/")
+                  (call-interactively 'self-insert-command))))))
 
 
 

--- a/modules/ohai-javascript.el
+++ b/modules/ohai-javascript.el
@@ -32,43 +32,44 @@
 
 ;; Install js2-mode, which improves on Emacs's default JS mode
 ;; tremendously.
-(package-require 'js2-mode)
-(add-to-list 'auto-mode-alist '("\\.js$" . js2-mode))
-(add-to-list 'auto-mode-alist '("\\.es6\\'" . js2-mode))
-(add-to-list 'auto-mode-alist '("\\.ejs\\'" . js2-mode))
-
-;; Configure js2-mode good.
-(setq-default
- js2-mode-indent-ignore-first-tab t
- js2-strict-inconsistent-return-warning nil
- js2-global-externs
- '("module" "require" "__dirname" "process" "console" "JSON" "$" "_"))
- ;; js2-show-parse-errors nil
- ;; js2-strict-var-hides-function-arg-warning nil
- ;; js2-strict-missing-semi-warning nil
- ;; js2-strict-trailing-comma-warning nil
- ;; js2-strict-cond-assign-warning nil
- ;; js2-strict-var-redeclaration-warning nil
+(use-package js2-mode
+  :config
+  (add-to-list 'auto-mode-alist '("\\.js$" . js2-mode))
+  (add-to-list 'auto-mode-alist '("\\.es6\\'" . js2-mode))
+  (add-to-list 'auto-mode-alist '("\\.ejs\\'" . js2-mode))
+  ;; Configure js2-mode good.
+  (setq-default
+   js2-mode-indent-ignore-first-tab t
+   js2-strict-inconsistent-return-warning nil
+   js2-global-externs
+   '("module" "require" "__dirname" "process" "console" "JSON" "$" "_"))
+  ;; js2-show-parse-errors nil
+  ;; js2-strict-var-hides-function-arg-warning nil
+  ;; js2-strict-missing-semi-warning nil
+  ;; js2-strict-trailing-comma-warning nil
+  ;; js2-strict-cond-assign-warning nil
+  ;; js2-strict-var-redeclaration-warning nil
+  )
 
 ;; Use Tern for smarter JS.
-(package-require 'tern)
-(add-hook 'js2-mode-hook (lambda () (tern-mode t)))
-
-;; Locate the Tern binary by querying the system search path, which
-;; should now include the local npm prefix.
-(setq tern-command (list (or (ohai/resolve-exec "tern") "tern")))
-
-;; Setup Tern as an autocomplete source.
-(with-eval-after-load "company"
-  (package-require 'company-tern)
-  (require 'company-tern)
-  (add-to-list 'company-backends 'company-tern))
+(use-package tern
+  :config
+  (add-hook 'js2-mode-hook (lambda () (tern-mode t)))
+  ;; Locate the Tern binary by querying the system search path, which
+  ;; should now include the local npm prefix.
+  (setq tern-command (list (or (ohai/resolve-exec "tern") "tern")))
+  ;; Setup Tern as an autocomplete source.
+  (with-eval-after-load "company"
+    (use-package company-tern
+      :config
+      (add-to-list 'company-backends 'company-tern))))
 
 ;; Leverage js2-mode to get some refactoring support through js2-refactor.
-(package-require 'js2-refactor)
-(add-hook 'js2-mode-hook
-          (lambda ()
-            (js2r-add-keybindings-with-prefix "C-c C-m")))
+(use-package js2-refactor
+  :config
+  (add-hook 'js2-mode-hook
+            (lambda ()
+              (js2r-add-keybindings-with-prefix "C-c C-m"))))
 
 
 

--- a/modules/ohai-js-web-mode.el
+++ b/modules/ohai-js-web-mode.el
@@ -31,38 +31,35 @@
   (setenv "PATH" (concat npm-prefix "/bin:" (getenv "PATH"))))
 
 ;; Use web-mode for all JS files.
-(package-require 'web-mode)
-(add-to-list 'auto-mode-alist '("\\.jsx?$" . web-mode))
-(add-to-list 'auto-mode-alist '("\\.es6\\'" . web-mode))
-(add-to-list 'auto-mode-alist '("\\.ejs\\'" . web-mode))
-
-(setq web-mode-content-types-alist
-      '(("jsx" . "\\.jsx?$")))
-
-;; Stop web-mode from using block comments in comment-dwim.
-(setq web-mode-comment-formats
-      (-map-when (lambda (i) (equal (car i) "javascript"))
-                 (lambda (i) '("javascript" . "//"))
-                 web-mode-comment-formats))
+(use-package web-mode
+  :config
+  (add-to-list 'auto-mode-alist '("\\.jsx?$" . web-mode))
+  (add-to-list 'auto-mode-alist '("\\.es6\\'" . web-mode))
+  (add-to-list 'auto-mode-alist '("\\.ejs\\'" . web-mode))
+  (setq web-mode-content-types-alist
+        '(("jsx" . "\\.jsx?$")))
+  ;; Stop web-mode from using block comments in comment-dwim.
+  (setq web-mode-comment-formats
+        (-map-when (lambda (i) (equal (car i) "javascript"))
+                   (lambda (i) '("javascript" . "//"))
+                   web-mode-comment-formats))
+  ;; Let Flycheck know that we're using web-mode for JS.
+  (with-eval-after-load "flycheck"
+    (flycheck-add-mode 'javascript-eslint 'web-mode)
+    (setq flycheck-javascript-eslint-executable (or (ohai/resolve-exec "eslint") "eslint"))))
 
 ;; Use Tern for smarter JS.
-(package-require 'tern)
-(add-hook 'web-mode-hook (lambda () (tern-mode t)))
-
-;; Locate the Tern binary by querying the system search path, which
-;; should now include the local npm prefix.
-(setq tern-command (list (or (ohai/resolve-exec "tern") "tern")))
-
-;; Setup Tern as an autocomplete source.
-(with-eval-after-load "company"
-  (package-require 'company-tern)
-  (require 'company-tern)
-  (add-to-list 'company-backends 'company-tern))
-
-;; Let Flycheck know that we're using web-mode for JS.
-(with-eval-after-load "flycheck"
-  (flycheck-add-mode 'javascript-eslint 'web-mode)
-  (setq flycheck-javascript-eslint-executable (or (ohai/resolve-exec "eslint") "eslint")))
+(use-package tern
+  :config
+  (add-hook 'web-mode-hook (lambda () (tern-mode t)))
+  ;; Locate the Tern binary by querying the system search path, which
+  ;; should now include the local npm prefix.
+  (setq tern-command (list (or (ohai/resolve-exec "tern") "tern")))
+  ;; Setup Tern as an autocomplete source.
+  (with-eval-after-load "company"
+    (use-package company-tern
+      :config
+      (add-to-list 'company-backends 'company-tern))))
 
 
 

--- a/modules/ohai-json.el
+++ b/modules/ohai-json.el
@@ -26,8 +26,10 @@
 ;;; Code:
 
 ;; Install json-mode and make its reformat keybinding match the global default.
-(package-require 'json-mode)
-(define-key json-mode-map (kbd "C-c <tab>") 'json-mode-beautify)
+(use-package json-mode
+  :config
+  (bind-keys :map json-mode-map
+             ("C-c <tab>" . json-mode-beautify)))
 
 (provide 'ohai-json)
 ;;; ohai-json.el ends here

--- a/modules/ohai-markdown.el
+++ b/modules/ohai-markdown.el
@@ -23,10 +23,9 @@
 (require 'ohai-package)
 
 ;; Install Markdown support.
-(package-require 'markdown-mode)
-(add-to-list 'auto-mode-alist '("\\.markdown$" . markdown-mode))
-(add-to-list 'auto-mode-alist '("\\.md$" . markdown-mode))
-
-
+(use-package markdown-mode
+  :config
+  (add-to-list 'auto-mode-alist '("\\.markdown$" . markdown-mode))
+  (add-to-list 'auto-mode-alist '("\\.md$" . markdown-mode)))
 
 (provide 'ohai-markdown)

--- a/modules/ohai-navigation.el
+++ b/modules/ohai-navigation.el
@@ -25,11 +25,13 @@
 
 ;; Avy is a quick way to jump around your buffers.
 ;; https://github.com/abo-abo/avy
-(package-require 'avy)
-(global-set-key (kbd "C-;") 'avy-goto-word-1)
-(global-set-key (kbd "C-:") 'avy-goto-char)
-(with-eval-after-load "isearch"
-  (define-key isearch-mode-map (kbd "C-;") 'avy-isearch))
+(use-package avy
+  :demand t
+  :bind (("C-;" . avy-goto-word-1)
+         ("C-:" . avy-goto-char))
+  :config
+  (with-eval-after-load "isearch"
+    (define-key isearch-mode-map (kbd "C-;") 'avy-isearch)))
 
 ;; Smart home key.
 (defun smart-beginning-of-line ()
@@ -46,9 +48,10 @@
 (global-subword-mode 1)
 
 ;; Enhance C-x o when more than two windows are open.
-(package-require 'ace-window)
-(global-set-key (kbd "C-x o") 'ace-window)
-(global-set-key (kbd "C-x C-o") 'ace-swap-window)
+(use-package ace-window
+  :bind (("C-x o" . ace-window)
+         ("C-x C-o" . ace-swap-window)))
+
 
 ;; Use C-x M-p to kill the buffer in the other window, revealing
 ;; the next buffer in the stack.
@@ -60,14 +63,16 @@
      (quit-window))))
 
 ;; Display incremental search stats in the modeline.
-(package-require 'anzu)
-(global-anzu-mode 1)
-
-;; Anzu provides a version of `query-replace' and friends which give visual
-;; feedback when composing regexps. Let's replace the regular versions.
-(global-set-key (kbd "C-%") 'anzu-query-replace-at-cursor)
-(global-set-key (kbd "M-%") 'anzu-query-replace)
-(global-set-key (kbd "C-M-%") 'anzu-query-replace-regexp)
+(use-package anzu
+  :demand t
+  :config
+  (global-anzu-mode 1)
+  ;; Anzu provides a version of `query-replace' and friends which give visual
+  ;; feedback when composing regexps. Let's replace the regular versions.
+  :bind(("C-%" . anzu-query-replace-at-cursor)
+        ("M-%" . anzu-query-replace)
+        ("C-M-%" . anzu-query-replace-regexp))
+  :diminish anzu-mode)
 
 
 

--- a/modules/ohai-orgmode.el
+++ b/modules/ohai-orgmode.el
@@ -22,25 +22,25 @@
 
 (require 'ohai-package)
 
-;; Stop org-mode from highjacking shift-cursor keys.
-(setq org-replace-disputed-keys t)
+(use-package org
+  :ensure org-plus-contrib
+  :config
+  ;; Stop org-mode from highjacking shift-cursor keys.
+  (setq org-replace-disputed-keys t)
+  ;; Always use visual-line-mode in org-mode, and wrap it at column 80.
+  (add-hook
+   'org-mode-hook
+   (lambda ()
+     (visual-line-mode 1)
+     (set-visual-wrap-column 80)))
+  ;; Fancy bullet rendering.
+  (use-package org-bullets
+    :config
+    (add-hook 'org-mode-hook (lambda () (org-bullets-mode 1))))
+  ;; Insert links from clipboard.
+  (use-package org-cliplink
+    :config
+    (with-eval-after-load "org"
+      (define-key org-mode-map (kbd "C-c M-l") 'org-cliplink))))
 
-;; Always use visual-line-mode in org-mode, and wrap it at column 80.
-(add-hook
- 'org-mode-hook
- (lambda ()
-   (visual-line-mode 1)
-   (set-visual-wrap-column 80)))
-
-;; Fancy bullet rendering.
-(package-require 'org-bullets)
-(add-hook 'org-mode-hook (lambda () (org-bullets-mode 1)))
-
-;; Insert links from clipboard.
-(package-require 'org-cliplink)
-(with-eval-after-load "org"
-  (define-key org-mode-map (kbd "C-c M-l") 'org-cliplink))
-
-
-
-(provide 'ohai-orgmode)
+  (provide 'ohai-orgmode)

--- a/modules/ohai-project.el
+++ b/modules/ohai-project.el
@@ -24,12 +24,12 @@
 
 ;; Install Projectile and activate it for all things.
 ;; Learn about Projectile: http://batsov.com/projectile/
-(package-require 'projectile)
-(projectile-global-mode)
-
-;; Use C-c C-f to find a file anywhere in the current project.
-(global-set-key (kbd "C-c C-f") 'projectile-find-file)
-
-
+(use-package projectile
+  :demand t
+  :config
+  (projectile-global-mode)
+  ;; Use C-c C-f to find a file anywhere in the current project.
+  :bind ("C-c C-f" . projectile-find-file)
+  :diminish projectile-mode)
 
 (provide 'ohai-project)

--- a/modules/ohai-purescript.el
+++ b/modules/ohai-purescript.el
@@ -24,48 +24,46 @@
 (require 'ohai-project)
 
 ;; Install purescript-mode.
-(package-require 'purescript-mode)
-(require 'purescript-mode)
-(add-to-list 'auto-mode-alist '("\\.purs$" . purescript-mode))
-(add-hook 'purescript-mode-hook 'turn-on-purescript-indentation)
+(use-package purescript-mode
+  :config
+  (add-to-list 'auto-mode-alist '("\\.purs$" . purescript-mode))
+  (add-hook 'purescript-mode-hook 'turn-on-purescript-indentation)
+  ;; Change some ASCII art syntax into their corresponding Unicode characters.
+  ;; Rebind the same Unicode characters to insert their ASCII art versions
+  ;; if entered from the keyboard.
+  (with-eval-after-load "purescript-mode"
+    (ohai/font-lock-replace-symbol 'purescript-mode "\\(->\\)" "→")
+    (ohai/font-lock-replace-symbol 'purescript-mode "\\(<-\\)" "←")
+    (ohai/font-lock-replace-symbol 'purescript-mode "\\(=>\\)" "⇒")
+    (define-key purescript-mode-map (kbd "→") (lambda () (interactive) (insert "->")))
+    (define-key purescript-mode-map (kbd "←") (lambda () (interactive) (insert "<-")))
+    (define-key purescript-mode-map (kbd "⇒") (lambda () (interactive) (insert "=>"))))
+  ;; Define a Flycheck checker for running the PureScript compiler through Pulp.
+  ;; This version comes from https://gist.github.com/cabrera/157699749ea71bae7a16
+  (with-eval-after-load "flycheck"
+    (flycheck-define-checker pulp
+      "Use Pulp to flycheck PureScript code."
+      :command ("pulp" "--monochrome" "build")
+      :error-patterns
+      ((error line-start
+              (or (and "Error at " (file-name) " line " line ", column " column
+                       (one-or-more not-newline)
+                       (message (one-or-more (not (in "*")))))
 
-;; Change some ASCII art syntax into their corresponding Unicode characters.
-;; Rebind the same Unicode characters to insert their ASCII art versions
-;; if entered from the keyboard.
-(with-eval-after-load "purescript-mode"
-  (ohai/font-lock-replace-symbol 'purescript-mode "\\(->\\)" "→")
-  (ohai/font-lock-replace-symbol 'purescript-mode "\\(<-\\)" "←")
-  (ohai/font-lock-replace-symbol 'purescript-mode "\\(=>\\)" "⇒")
-  (define-key purescript-mode-map (kbd "→") (lambda () (interactive) (insert "->")))
-  (define-key purescript-mode-map (kbd "←") (lambda () (interactive) (insert "<-")))
-  (define-key purescript-mode-map (kbd "⇒") (lambda () (interactive) (insert "=>"))))
+                  (and "psc: " (one-or-more not-newline) "\n"
+                       (message (one-or-more not-newline) "\n")
+                       "at \"" (file-name) "\" (line " line ", column " column ")")
+                  (and "Unable to parse module:\n"
+                       "  \"" (file-name) "\" (line " line ", column " column "):\n"
+                       (message (one-or-more not-newline) "\n"
+                                (one-or-more not-newline) "\n"
+                                (one-or-more not-newline) "\n"))
+                  )
 
-;; Define a Flycheck checker for running the PureScript compiler through Pulp.
-;; This version comes from https://gist.github.com/cabrera/157699749ea71bae7a16
-(with-eval-after-load "flycheck"
-  (flycheck-define-checker pulp
-    "Use Pulp to flycheck PureScript code."
-    :command ("pulp" "--monochrome" "build")
-    :error-patterns
-    ((error line-start
-            (or (and "Error at " (file-name) " line " line ", column " column
-                     (one-or-more not-newline)
-                     (message (one-or-more (not (in "*")))))
-
-                (and "psc: " (one-or-more not-newline) "\n"
-                     (message (one-or-more not-newline) "\n")
-                     "at \"" (file-name) "\" (line " line ", column " column ")")
-                (and "Unable to parse module:\n"
-                     "  \"" (file-name) "\" (line " line ", column " column "):\n"
-                     (message (one-or-more not-newline) "\n"
-                              (one-or-more not-newline) "\n"
-                              (one-or-more not-newline) "\n"))
-                )
-
-            line-end
-            ))
-    :modes purescript-mode)
-  (add-to-list 'flycheck-checkers 'pulp))
+              line-end
+              ))
+      :modes purescript-mode)
+    (add-to-list 'flycheck-checkers 'pulp)))
 
 ;; A function for generating a likely module name from the current file path.
 ;; We use this in the `ps.module' snippet.
@@ -80,13 +78,13 @@
         (if (string= ".." (car testpath)) "Main" (s-join "." (cons "Test" testpath)))
       (s-join "." path))))
 
-;; psc-ide
-(setq psc-ide-executable (or (ohai/resolve-exec "psc-ide") "psc-ide"))
-(setq psc-ide-server-executable (or (ohai/resolve-exec "psc-ide-server") "psc-ide-server"))
-(package-require 'psc-ide)
-(add-hook 'purescript-mode-hook 'psc-ide-mode)
-
-
+(use-package psc-ide
+  :init
+  ;; psc-ide
+  (setq psc-ide-executable (or (ohai/resolve-exec "psc-ide") "psc-ide"))
+  (setq psc-ide-server-executable (or (ohai/resolve-exec "psc-ide-server") "psc-ide-server"))
+  :config
+  (add-hook 'purescript-mode-hook 'psc-ide-mode))
 
 (provide 'ohai-purescript)
 ;;; ohai-purescript.el ends here

--- a/modules/ohai-refactor.el
+++ b/modules/ohai-refactor.el
@@ -20,13 +20,11 @@
 
 ;;; Code:
 
-(package-require 'emr)
-(add-hook 'prog-mode-hook 'emr-initialize)
-
-;; Just hit M-RET to access your refactoring tools in any supported mode.
-(define-key prog-mode-map (kbd "M-RET") 'emr-show-refactor-menu)
-
-
+(use-package emr
+  :config
+  (add-hook 'prog-mode-hook 'emr-initialize)
+  ;; Just hit M-RET to access your refactoring tools in any supported mode.
+  (define-key prog-mode-map (kbd "M-RET") 'emr-show-refactor-menu))
 
 (provide 'ohai-refactor)
 ;;; ohai-refactor.el ends here

--- a/modules/ohai-snippets.el
+++ b/modules/ohai-snippets.el
@@ -23,16 +23,14 @@
 (require 'ohai-package)
 
 ;; The s.el package contains a lot of functions useful in snippets.
-(package-require 's)
-(require 's)
+(use-package s)
 
 ;; Install yasnippet and make it available globally.
 ;; Read about it here: http://capitaomorte.github.io/yasnippet/
-(package-require 'yasnippet)
-(require 'yasnippet)
-(yas-global-mode 1)
-
-
+(use-package yasnippet
+  :config
+  (yas-global-mode 1)
+  :diminish yas-minor-mode)
 
 (provide 'ohai-snippets)
 ;;; ohai-snippets.el ends here

--- a/modules/ohai-splash.el
+++ b/modules/ohai-splash.el
@@ -30,13 +30,10 @@
        ((equal ohai-personal-taste/splash 'daily-otter)
         '(ohai-splash/daily-otter))))
 
-(package-require 'dash)
-(package-require 's)
-(package-require 'web)
+(use-package dash)
+(use-package s)
+(use-package web)
 
-(require 'dash)
-(require 's)
-(require 'web)
 
 (defun ohai-splash/load-and-map (url map-fn cb)
   (web-http-get

--- a/modules/ohai-unicode.el
+++ b/modules/ohai-unicode.el
@@ -27,8 +27,9 @@
 ;; You'll need to make sure the necessary fonts are installed for this to
 ;; work. See https://github.com/rolandwalker/unicode-fonts/#quickstart
 
-(package-require 'unicode-fonts)
-(unicode-fonts-setup)
+(use-package unicode-fonts
+  :config
+  (unicode-fonts-setup))
 
 
 

--- a/ohai/ohai-lib.el
+++ b/ohai/ohai-lib.el
@@ -26,12 +26,9 @@
 ;; f.el    - files and paths  https://github.com/rejeep/f.el
 ;; s.el    - strings          https://github.com/magnars/s.el
 ;; dash.el - lists            https://github.com/magnars/dash.el
-(package-require 'f)
-(require 'f)
-(package-require 's)
-(require 's)
-(package-require 'dash)
-(require 'dash)
+(use-package f)
+(use-package s)
+(use-package dash)
 
 
 

--- a/ohai/ohai-package.el
+++ b/ohai/ohai-package.el
@@ -55,6 +55,12 @@
 (when (not (package-installed-p 'paradox))
   (package-install 'paradox))
 
+(when (not (package-installed-p 'use-package))
+  (package-install 'use-package))
+
+(require 'use-package)
+(setq use-package-always-ensure t)
+
 ;; We're going to try to declare the packages each feature needs as we
 ;; define it. To do this, we define a function `(package-require)`
 ;; which will fetch and install a package from the repositories if it


### PR DESCRIPTION
Upgrade package management system to use use-package instead of
package-require function. package-require is still available for
backwards-compatibility.

Use-package is great, and has the following benefits over plain
requires:
- Organized config code contained within its own macro
- Elegant construction of common package related operations.
- Soft require of packages in case there is an error loading file.
- Reduced startup time.
- Easy disabling of packages you don't want to use.
- Built in declaration to diminish modes.
- Package specific code executed in sandbox saving emacs from
  crippling.
- Guaranteed download and installation from package.el.

Drawbacks to making the switch:
- Lots of code changes almost in every file.
- It's not a problem that needs to be solved right now.
- Outcry from users who extended ohai-emacs; may need to deal with
  merge conflicts :(
- Weird behavior of packages and might need further tweaking.
