### PR TITLE
cleans up the purescript module

### DIFF
--- a/modules/ohai-purescript.el
+++ b/modules/ohai-purescript.el
@@ -51,14 +51,9 @@
 (use-package psc-ide
   :init
   ;; psc-ide
-  (setq psc-ide-client-executable (or (ohai/resolve-exec "psc-ide-client") "psc-ide-client"))
   (setq psc-ide-server-executable (or (ohai/resolve-exec "psc-ide-server") "psc-ide-server"))
-  (setq psc-ide-rebuild-on-save nil)
   :config
   (add-hook 'purescript-mode-hook 'psc-ide-mode))
-
-;; Stop eldoc's whining.
-(defun purescript-doc-current-info () nil)
 
 (provide 'ohai-purescript)
 ;;; ohai-purescript.el ends here


### PR DESCRIPTION
I think the `ohai-purescript` module is being used as a reference for configuring `psc-ide-mode` so I'd like to suggest these changes. Eldoc mode has been working for a while now for me, but you might want to confirm it is actually fixed on your end.

* removes reference to psc-ide-client
* removes rebuild on save configurations as `nil` is the default anyway
* eldoc support should be fixed, so remove a workaround
