### PR TITLE
Update ohai-appearance.el

### DIFF
--- a/modules/ohai-appearance.el
+++ b/modules/ohai-appearance.el
@@ -140,7 +140,7 @@
 (setq linum-disabled-modes
       '(term-mode slime-repl-mode magit-status-mode help-mode nrepl-mode
         mu4e-main-mode mu4e-headers-mode mu4e-view-mode
-        mu4e-compose-mode))
+        mu4e-compose-mode org-mode))
 (defun linum-on ()
   (unless (or (minibufferp) (member major-mode linum-disabled-modes))
     (linum-mode 1)))


### PR DESCRIPTION
Fixes an incompatibility between linum and org-mode modules - when I use org-mode with largish org files (eg 32k lines in 1Mb) it hangs emacs in a seemingly infinite loop.