### PR TITLE
Fixed issue involving emacs always opening in scratch buffer

### DIFF
--- a/modules/ohai-splash.el
+++ b/modules/ohai-splash.el
@@ -137,9 +137,6 @@
     (ohai-splash/run nil (lambda (img) (ohai-splash/inject-picture img))))
   t)
 
-(when window-system
-  (setq initial-buffer-choice 'ohai-splash/go))
-
 ;; A hack here to force the splash screen after the first run wizard's
 ;; module selection, as `initial-buffer-choice' will already have run.
 (when (boundp 'ohai/wizard-did-run)


### PR DESCRIPTION
Fixes issue #25 involving emacs always opening in scratch buffer, even when a filename is provided.